### PR TITLE
[chore] vsc 임포트 경로 path alias 사용을 할 수 있게 세팅

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,5 +27,6 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true
   },
-  "workbench.settings.useSplitJSON": true
+  "workbench.settings.useSplitJSON": true,
+  "typescript.preferences.importModuleSpecifier": "non-relative"
 }


### PR DESCRIPTION
# 이 풀리퀘스트는 다음과 같습니다

## 배경

현재 임포트 경로를 상대 경로가 아닌 절대 경로 (path alias)를 사용하도록 규칙을 정해 사용중입니다.
하지만 vs code에서 intellisence를 통해 임포트할 경우 상대 경로로 완성이 되고, 이를 수동으로 반영해야합니다.
이 부분을 수정합니다.

| Before | After |
| :---: | :---: |
| ![스크린샷 2023-03-08 오전 10 24 47](https://user-images.githubusercontent.com/35859756/223595618-4149398c-67e8-4a5c-af6e-166db31a3f52.png) | ![스크린샷 2023-03-08 오전 10 25 47](https://user-images.githubusercontent.com/35859756/223595624-3173b967-797b-4700-b854-3a71de522f14.png) |


## 작업내용

- vsc setting 변경

## 리뷰어에게

머지가 된다면
1. git pull
2. ts 혹은 tsx 파일에서 커맨드 + 쉬프트 + p 명령어 실행 -> restart TS Server 해주시면 됩니다