### PR TITLE
[Fix] null 값 에러

### DIFF
--- a/src/constants/schema/passwordChangeSchema.ts
+++ b/src/constants/schema/passwordChangeSchema.ts
@@ -12,6 +12,7 @@ export const passwordChangeSchema = yup
     newPasswordCheck: yup
       .string()
       .required('비밀번호를 확인해주세요.')
+      .nullable()
       .oneOf([yup.ref('firstPassword'), null], '비밀번호가 일치하지 않습니다.'),
   })
   .required();

--- a/src/constants/schema/registerSchema.ts
+++ b/src/constants/schema/registerSchema.ts
@@ -18,6 +18,7 @@ export const registerSchema = yup
     password_check: yup
       .string()
       .required('비밀번호를 확인해주세요.')
+      .nullable()
       .oneOf([yup.ref('password'), null], '비밀번호가 일치하지 않습니다.'),
     field: yup.string(),
   })


### PR DESCRIPTION
# 이 풀리퀘스트는 다음과 같습니다

## 배경

- 입력한 비밀번호와 일치하는지 확인하는 검사에서의 ''null' 형식은 'string | Reference<unknown>' 형식에 할당할 수 없습니다.' 에러 발생

## 작업내용

- 에러가 발생하여 nullable() 추가하였습니다.

참고 (https://github.com/jquense/yup/issues/1350) > If you omit nullable() then an error gets thrown, something like "expected an object but received null".

## 리뷰어에게

