### PR TITLE
[Feat] 소셜 로그인 후 로그아웃 시 localStorage 삭제

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -24,6 +24,7 @@ const Header: FC = () => {
       localStorage.removeItem('userId');
       localStorage.removeItem('authorization');
       localStorage.removeItem('refresh');
+      localStorage.removeItem('oauth');
       setIsLogin(false);
       alert('로그아웃 완료!');
       navigate('/');

--- a/src/pages/user/UserInfo.tsx
+++ b/src/pages/user/UserInfo.tsx
@@ -31,6 +31,7 @@ const UserInfo: FC = () => {
       localStorage.removeItem('userId');
       localStorage.removeItem('authorization');
       localStorage.removeItem('refresh');
+      localStorage.removeItem('oauth');
       window.location.href = '/';
     },
     onError: (err) => {


### PR DESCRIPTION
# 이 풀리퀘스트는 다음과 같습니다

## 배경

- 소셜 로그아웃 시 localStorage 에 저장된 'oauth' 키 삭제

## 작업내용

- 소셜 로그인 후에  localStorage 에 저장된 'oauth' 키를 로그아웃&회원탈퇴 시 삭제되도록 추가작업 진행했습니다. 

## 리뷰어에게
