### PR TITLE
[Feat] 구인글 생성 

### DIFF
--- a/src/api/recruit/recruitAPI.ts
+++ b/src/api/recruit/recruitAPI.ts
@@ -1,5 +1,5 @@
 import axiosInstance from '@/api/axiosInstance';
-import type { Recruit } from '@/api/recruit/recruitTypes';
+import type { PostRecruitReq, Recruit } from '@/api/recruit/recruitTypes';
 
 interface PaginationResponse<T> {
   data: T;
@@ -32,3 +32,6 @@ export const getRecruits = async (pageNum: number, category: string | null, sort
 
 // export const getSearchNofield = (pageNum: number, sort: string, search: string | null) =>
 //   axiosInstance.get(`api/study?page=${pageNum}&size=12&sort=${sort}&search=${search}`);
+
+export const postRecruit = ({ studyId, body }: { studyId: number; body: PostRecruitReq }) =>
+  axiosInstance.post(`/api/offer/study/${studyId}`, body);

--- a/src/api/recruit/recruitTypes.ts
+++ b/src/api/recruit/recruitTypes.ts
@@ -22,3 +22,8 @@ export interface Recruit extends RecruitStack, RecruitOwner {
   online: boolean;
   checkLikes: boolean;
 }
+
+export interface PostRecruitReq {
+  offerIntro: string;
+  offerRule: string;
+}

--- a/src/api/study/studyTypes.ts
+++ b/src/api/study/studyTypes.ts
@@ -34,6 +34,9 @@ export interface GetStudyDetailRes {
   place: string;
   latitude: number;
   longitude: number;
+  studyStatus: string;
+  period: string;
+  online: boolean;
   stack: Stack[];
   owner: StudyOwner;
 }

--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -30,11 +30,6 @@ const Footer: FC = () => {
                   스터디 수정
                 </Button>
               </Link>
-              <Link to="/recruit/create/266">
-                <Button size="small" color="gray" text>
-                  구인 글 생성
-                </Button>
-              </Link>
               <Link to="/recruit/edit">
                 <Button size="small" color="gray" text>
                   구인 글 수정

--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -30,7 +30,7 @@ const Footer: FC = () => {
                   스터디 수정
                 </Button>
               </Link>
-              <Link to="/recruit/create">
+              <Link to="/recruit/create/266">
                 <Button size="small" color="gray" text>
                   구인 글 생성
                 </Button>

--- a/src/components/common/StudyDetailIntro.tsx
+++ b/src/components/common/StudyDetailIntro.tsx
@@ -6,7 +6,7 @@ import type { GetStudyDetailRes } from '@/api/study/studyTypes';
 
 interface Props {
   detailData?: GetStudyDetailRes;
-  onClick: () => void;
+  onClick?: () => void;
 }
 
 const StudyDetailIntro: FC<Props> = ({ detailData, onClick }: Props) => {

--- a/src/components/mypage/sutdyBlock/StudyBlock.tsx
+++ b/src/components/mypage/sutdyBlock/StudyBlock.tsx
@@ -2,6 +2,7 @@ import StudyPeriod from '@/components/mypage/sutdyBlock/StudyPeriod';
 import type { FC } from 'react';
 import StudyIntro from '@/components/mypage/sutdyBlock/StudyIntro';
 import type { Stack } from '@/api/auth/types';
+import { Link } from 'react-router-dom';
 
 interface Props {
   studyData: {
@@ -12,12 +13,19 @@ interface Props {
     stack: Stack[];
   };
   isDetail?: boolean;
+  isRecruit?: boolean;
 }
 
-const StudyBlock: FC<Props> = ({ studyData: { endDate, startDate, title, stack, studyId }, isDetail }: Props) => {
+const StudyBlock: FC<Props> = ({
+  studyData: { endDate, startDate, title, stack, studyId },
+  isDetail,
+  isRecruit,
+}: Props) => {
   return (
     <div className="studyBlock-container">
-      <StudyIntro title={title} stacks={stack} isDetail={isDetail} studyId={studyId} />
+      <Link to={isRecruit ? `/recruit/create/${studyId}` : ''}>
+        <StudyIntro title={title} stacks={stack} isDetail={isDetail} studyId={studyId} />
+      </Link>
       <StudyPeriod startDate={startDate} endDate={endDate} />
     </div>
   );

--- a/src/components/mypage/sutdyBlock/StudyBlock.tsx
+++ b/src/components/mypage/sutdyBlock/StudyBlock.tsx
@@ -2,7 +2,6 @@ import StudyPeriod from '@/components/mypage/sutdyBlock/StudyPeriod';
 import type { FC } from 'react';
 import StudyIntro from '@/components/mypage/sutdyBlock/StudyIntro';
 import type { Stack } from '@/api/auth/types';
-import { Link } from 'react-router-dom';
 
 interface Props {
   studyData: {
@@ -23,9 +22,7 @@ const StudyBlock: FC<Props> = ({
 }: Props) => {
   return (
     <div className="studyBlock-container">
-      <Link to={isRecruit ? `/recruit/create/${studyId}` : ''}>
-        <StudyIntro title={title} stacks={stack} isDetail={isDetail} studyId={studyId} />
-      </Link>
+      <StudyIntro title={title} stacks={stack} isDetail={isDetail} studyId={studyId} isRecruit={isRecruit} />
       <StudyPeriod startDate={startDate} endDate={endDate} />
     </div>
   );

--- a/src/components/mypage/sutdyBlock/StudyIntro.tsx
+++ b/src/components/mypage/sutdyBlock/StudyIntro.tsx
@@ -11,9 +11,7 @@ interface Props {
 const StudyIntro: FC<Props> = ({ title, stacks, isDetail, studyId }: Props) => {
   return (
     <div className="title-container">
-      <div className="title">
-        <Link to={isDetail ? `/study/${studyId}` : '/'}>{title}</Link>
-      </div>
+      <div className="title">{isDetail ? <Link to={`/study/${studyId}`}>{title}</Link> : <>{title}</>}</div>
       <div className="stacks">
         {stacks.map(({ stackId, stackName }) => (
           <p key={stackId}>{stackName}</p>

--- a/src/components/mypage/sutdyBlock/StudyIntro.tsx
+++ b/src/components/mypage/sutdyBlock/StudyIntro.tsx
@@ -13,7 +13,9 @@ const StudyIntro: FC<Props> = ({ title, stacks, isDetail, studyId, isRecruit }: 
   const linkTo = isRecruit ? `/recruit/create/${studyId}` : `/study/${studyId}`;
   return (
     <div className="title-container">
-      <div className="title">{isDetail || isRecruit ? <Link to={linkTo}>{title}</Link> : <>{title}</>}</div>
+      <div className="title">
+        <Link to={isDetail || isRecruit ? linkTo : ''}>{title}</Link>
+      </div>
       <div className="stacks">
         {stacks.map(({ stackId, stackName }) => (
           <p key={stackId}>{stackName}</p>

--- a/src/components/mypage/sutdyBlock/StudyIntro.tsx
+++ b/src/components/mypage/sutdyBlock/StudyIntro.tsx
@@ -6,12 +6,14 @@ interface Props {
   stacks: { stackId: number; stackName: string }[];
   studyId: number;
   isDetail?: boolean;
+  isRecruit?: boolean;
 }
 
-const StudyIntro: FC<Props> = ({ title, stacks, isDetail, studyId }: Props) => {
+const StudyIntro: FC<Props> = ({ title, stacks, isDetail, studyId, isRecruit }: Props) => {
+  const linkTo = isRecruit ? `/recruit/create/${studyId}` : `/study/${studyId}`;
   return (
     <div className="title-container">
-      <div className="title">{isDetail ? <Link to={`/study/${studyId}`}>{title}</Link> : <>{title}</>}</div>
+      <div className="title">{isDetail || isRecruit ? <Link to={linkTo}>{title}</Link> : <>{title}</>}</div>
       <div className="stacks">
         {stacks.map(({ stackId, stackName }) => (
           <p key={stackId}>{stackName}</p>

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -8,6 +8,7 @@ import '@/styles/main.scss';
 import Search from '@/components/main/Search/Search';
 import useDebounce from '@/hooks/useDebounce';
 import type { Recruit } from '@/api/recruit/recruitTypes';
+import { Link } from 'react-router-dom';
 
 const Main: FC = () => {
   const [search, setSearch] = useState<string | null>('');
@@ -71,7 +72,9 @@ const Main: FC = () => {
       <ul className="row recruit-card-wrapper">
         {data?.data?.map((post: Recruit) => (
           <li key={post.studyId} className="col-lg-3 col-md-6 col-sm-4">
-            <RecruitCard recruit={post} />
+            <Link to={`/recruit/detail/${post.studyId}`}>
+              <RecruitCard recruit={post} />
+            </Link>
           </li>
         ))}
       </ul>

--- a/src/pages/recruit/Create.tsx
+++ b/src/pages/recruit/Create.tsx
@@ -1,11 +1,17 @@
+import { postRecruit } from '@/api/recruit/recruitAPI';
+import type { PostRecruitReq } from '@/api/recruit/recruitTypes';
 import { getStudyDetail } from '@/api/study/studyAPI';
 import Button from '@/components/common/Button';
 import StudyDetailIntro from '@/components/common/StudyDetailIntro';
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import type { FC } from 'react';
+import { type SubmitHandler, useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
 
 const RecruitCreate: FC = () => {
   const studyId = 266;
+  const navigate = useNavigate();
+  const { register, handleSubmit } = useForm<PostRecruitReq>();
 
   const { data } = useQuery({
     queryFn: () => getStudyDetail(Number(studyId)),
@@ -13,12 +19,27 @@ const RecruitCreate: FC = () => {
     select: ({ data }) => data,
   });
 
+  const { mutate: postNewRecruit } = useMutation(postRecruit, {
+    onSuccess: () => {
+      alert('구인글이 작성되었습니다!');
+      navigate('/');
+    },
+  });
+
+  const onClickGoBack = () => {
+    navigate(-1);
+  };
+
+  const onSumbit: SubmitHandler<PostRecruitReq> = (data) => {
+    postNewRecruit({ studyId, body: data });
+  };
+
   return (
     <div className="container">
       <div className="row">
         <div className="col-lg-12">
           <div className="title-area">
-            <button>
+            <button onClick={onClickGoBack}>
               <i className="icon-arrow-left"></i>
             </button>
             <p>구인 글 생성하기</p>
@@ -26,15 +47,15 @@ const RecruitCreate: FC = () => {
           </div>
           <StudyDetailIntro detailData={data} />
 
-          <div className="add-recruit-box">
+          <form className="add-recruit-box" onSubmit={handleSubmit(onSumbit)} id="recruit">
             <div className="recruit-intro">
               <p>스터디 소개</p>
-              <textarea placeholder="내용을 작성해주세요." required name="recruit-intro" />
+              <textarea placeholder="내용을 작성해주세요." required form="recruit" {...register('offerIntro')} />
             </div>
 
             <div className="recruit-rule">
               <p>스터디 규칙</p>
-              <textarea placeholder="내용을 작성해주세요." required name="recruit-intro" />
+              <textarea placeholder="내용을 작성해주세요." required form="recruit" {...register('offerRule')} />
             </div>
             <div className="button-area">
               <Button size="large" color="gray" outline>
@@ -44,7 +65,7 @@ const RecruitCreate: FC = () => {
                 생성하기
               </Button>
             </div>
-          </div>
+          </form>
         </div>
       </div>
     </div>

--- a/src/pages/recruit/Create.tsx
+++ b/src/pages/recruit/Create.tsx
@@ -1,7 +1,54 @@
+import { getStudyDetail } from '@/api/study/studyAPI';
+import Button from '@/components/common/Button';
+import StudyDetailIntro from '@/components/common/StudyDetailIntro';
+import { useQuery } from '@tanstack/react-query';
 import type { FC } from 'react';
 
 const RecruitCreate: FC = () => {
-  return <div>구인 글 create</div>;
+  const studyId = 266;
+
+  const { data } = useQuery({
+    queryFn: () => getStudyDetail(Number(studyId)),
+    queryKey: ['studyDetail', studyId],
+    select: ({ data }) => data,
+  });
+
+  return (
+    <div className="container">
+      <div className="row">
+        <div className="col-lg-12">
+          <div className="title-area">
+            <button>
+              <i className="icon-arrow-left"></i>
+            </button>
+            <p>구인 글 생성하기</p>
+            <div />
+          </div>
+          <StudyDetailIntro detailData={data} />
+
+          <div className="add-recruit-box">
+            <div className="recruit-intro">
+              <p>스터디 소개</p>
+              <textarea placeholder="내용을 작성해주세요." required name="recruit-intro" />
+            </div>
+
+            <div className="recruit-rule">
+              <p>스터디 규칙</p>
+              <textarea placeholder="내용을 작성해주세요." required name="recruit-intro" />
+            </div>
+            <div className="button-area">
+              <Button size="large" color="gray" outline>
+                취소
+              </Button>
+              <Button size="large" type="submit">
+                생성하기
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
 };
 
 export default RecruitCreate;

--- a/src/pages/recruit/Create.tsx
+++ b/src/pages/recruit/Create.tsx
@@ -6,10 +6,10 @@ import StudyDetailIntro from '@/components/common/StudyDetailIntro';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import type { FC } from 'react';
 import { type SubmitHandler, useForm } from 'react-hook-form';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 const RecruitCreate: FC = () => {
-  const studyId = 266;
+  const { studyId } = useParams();
   const navigate = useNavigate();
   const { register, handleSubmit } = useForm<PostRecruitReq>();
 
@@ -31,7 +31,7 @@ const RecruitCreate: FC = () => {
   };
 
   const onSumbit: SubmitHandler<PostRecruitReq> = (data) => {
-    postNewRecruit({ studyId, body: data });
+    postNewRecruit({ studyId: Number(studyId), body: data });
   };
 
   return (

--- a/src/pages/recruit/Create.tsx
+++ b/src/pages/recruit/Create.tsx
@@ -22,7 +22,7 @@ const RecruitCreate: FC = () => {
   const { mutate: postNewRecruit } = useMutation(postRecruit, {
     onSuccess: () => {
       alert('구인글이 작성되었습니다!');
-      navigate('/');
+      navigate(`/recruit/detail/${studyId}`);
     },
   });
 

--- a/src/pages/recruit/Detail.tsx
+++ b/src/pages/recruit/Detail.tsx
@@ -1,0 +1,13 @@
+import type { FC } from 'react';
+
+const RecruitDetail: FC = () => {
+  return (
+    <div className="container">
+      <div className="row">
+        <div className="col-lg-12">구인글 디테일 페이지</div>
+      </div>
+    </div>
+  );
+};
+
+export default RecruitDetail;

--- a/src/pages/user/UserCreateStudy.tsx
+++ b/src/pages/user/UserCreateStudy.tsx
@@ -41,7 +41,7 @@ const UserCreateStudy: FC = () => {
         ) : (
           data.data.map(({ studyId, endDate, startDate, title, stack }) => {
             const studyData = { endDate, startDate, title, stack, studyId };
-            return <StudyBlock key={studyId} studyData={studyData} />;
+            return <StudyBlock key={studyId} studyData={studyData} isRecruit={selectOption === 'before_recruitment'} />;
           })
         )}
       </div>

--- a/src/routes/RoutesSetup.tsx
+++ b/src/routes/RoutesSetup.tsx
@@ -43,7 +43,7 @@ export const RoutesSetup = () => {
         <Route path="edit" element={<StudyEdit />} />
       </Route>
       <Route path="/recruit">
-        <Route path="create" element={<RecruitCreate />} />
+        <Route path="create/:studyId" element={<RecruitCreate />} />
         <Route path="edit" element={<RecruitEdit />} />
       </Route>
 

--- a/src/routes/RoutesSetup.tsx
+++ b/src/routes/RoutesSetup.tsx
@@ -18,6 +18,7 @@ import UserCreateStudy from '@/pages/user/UserCreateStudy';
 import UserStudy from '@/pages/user/UserStudy';
 import UserLikeStudy from '@/pages/user/UserLikeStudy';
 import OauthToken from '@/pages/OauthToken';
+import RecruitDetail from '@/pages/recruit/Detail';
 
 export const RoutesSetup = () => {
   return (
@@ -43,6 +44,7 @@ export const RoutesSetup = () => {
         <Route path="edit" element={<StudyEdit />} />
       </Route>
       <Route path="/recruit">
+        <Route path="detail/:studyId" element={<RecruitDetail />} />
         <Route path="create/:studyId" element={<RecruitCreate />} />
         <Route path="edit" element={<RecruitEdit />} />
       </Route>

--- a/src/styles/components/_createStudy.scss
+++ b/src/styles/components/_createStudy.scss
@@ -1,22 +1,22 @@
+.title-area {
+  margin: 40px 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  p {
+    @include text-style-46;
+    text-align: center;
+    font-weight: 600;
+  }
+  i {
+    @include text-style-24;
+  }
+}
+
 .section-form {
   padding: 0;
   margin: 0 auto;
-
-  .title-area {
-    margin: 60px 0;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-
-    p {
-      @include text-style-46;
-      text-align: center;
-      font-weight: 600;
-    }
-    i {
-      @include text-style-24;
-    }
-  }
 
   .main-info,
   .additional-info {
@@ -67,16 +67,16 @@
     }
   }
 
-  .button-area {
-    text-align: right;
-    border-top: 1px solid $border;
-    padding-right: 30px;
-    padding-top: 20px;
-  }
-
   .content-title {
     margin-bottom: 10px;
   }
+}
+
+.button-area {
+  text-align: right;
+  border-top: 1px solid $border;
+  padding-right: 30px;
+  padding-top: 20px;
 }
 
 .dropdown-wrapper {

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -39,5 +39,8 @@
 @import 'components/createStudy';
 @import 'components/calendarPeriod';
 
+/* 페이지 */
+@import 'pages/createRecruit';
+
 /* 레이아웃 */
 @import 'layouts/grids';

--- a/src/styles/pages/_createRecruit.scss
+++ b/src/styles/pages/_createRecruit.scss
@@ -23,4 +23,5 @@ textarea {
   border: 1px solid $border;
   border-radius: 6px;
   padding: 20px;
+  resize: none;
 }

--- a/src/styles/pages/_createRecruit.scss
+++ b/src/styles/pages/_createRecruit.scss
@@ -1,0 +1,26 @@
+.add-recruit-box {
+  background-color: $white;
+  border-radius: 16px;
+  margin-top: 30px;
+  padding-bottom: 20px;
+  margin-bottom: 60px;
+}
+
+.add-recruit-box {
+  @include flexbox();
+  flex-direction: column;
+  gap: 20px;
+  padding: 10px;
+
+  .button-area {
+    width: 100%;
+  }
+}
+
+textarea {
+  width: 900px;
+  height: 400px;
+  border: 1px solid $border;
+  border-radius: 6px;
+  padding: 20px;
+}


### PR DESCRIPTION
# 이 풀리퀘스트는 다음과 같습니다

## 배경

- '모집전' 스터디의 구인글을 작성하는 페이지 작업을 했습니다. 

## 작업내용

- '모집전' 상태인 스터디를 클릭하면 구인글 작성을 할 수 있는 페이지로 이동합니다.
- 구인글을 생성하면 구인글 상세 페이지로 이동합니다. 

https://github.com/spam-mayo/mayo-frontend/assets/110615050/e3a1d65f-2f70-4778-ba97-b38d32b63d63

## 리뷰어에게

- 각 스터디를 클릭하면 이동할 수 있는 페이지가 다른데, 이 부분은 다시 수정해보겠습니다. 
