### PR TITLE
[Refactor] 사용자 프로필 사진 전역 관리 

### DIFF
--- a/src/api/auth/types.ts
+++ b/src/api/auth/types.ts
@@ -51,3 +51,8 @@ export interface GetUserRes {
   field: string;
   stack: Stack[];
 }
+
+export interface UserState {
+  userId: number | null;
+  profileUrl: string;
+}

--- a/src/atom/atom.ts
+++ b/src/atom/atom.ts
@@ -1,10 +1,14 @@
+import type { UserState } from '@/api/auth/types';
 import { atom } from 'recoil';
 import { recoilPersist } from 'recoil-persist';
 
 const { persistAtom } = recoilPersist();
 
-export const userIdState = atom<number | null>({
+export const userState = atom<UserState>({
   key: 'userIdState',
-  default: null,
+  default: {
+    userId: null,
+    profileUrl: '',
+  },
   effects_UNSTABLE: [persistAtom],
 });

--- a/src/components/common/AddUserComment.tsx
+++ b/src/components/common/AddUserComment.tsx
@@ -1,10 +1,10 @@
 import UserProfileImg from '@/components/common/UserProfileImg';
+import useUser from '@/hooks/useUser';
 import classNames from 'classnames';
 import { type FC, useState } from 'react';
 import { useForm } from 'react-hook-form';
 
 interface Props {
-  profileUrl?: string;
   onSubmitPostComment: (data: CommentFormValue) => void;
 }
 
@@ -12,9 +12,10 @@ export interface CommentFormValue {
   comment: string;
 }
 
-const AddUserComment: FC<Props> = ({ profileUrl, onSubmitPostComment }) => {
+const AddUserComment: FC<Props> = ({ onSubmitPostComment }) => {
   const { handleSubmit, register, reset } = useForm<CommentFormValue>();
   const [isInputEmpty, setIsInputEmpty] = useState(true);
+  const { userProfile } = useUser();
 
   const onSubmit = (data: CommentFormValue) => {
     onSubmitPostComment(data);
@@ -29,7 +30,7 @@ const AddUserComment: FC<Props> = ({ profileUrl, onSubmitPostComment }) => {
     <div>
       <p className="comment-title">댓글</p>
       <form className="comment-input-container" onSubmit={handleSubmit(onSubmit)}>
-        <UserProfileImg src={profileUrl} />
+        <UserProfileImg src={userProfile} />
         <input {...register('comment')} onChange={handleInputChange} />
         <button type="submit" disabled={isInputEmpty} className={classNames({ disabled: isInputEmpty })}>
           등록하기

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -4,20 +4,12 @@ import { Link } from 'react-router-dom';
 import HeaderProfile from '@/components/common/HeaderProfile';
 import UserProfileImg from '@/components/common/UserProfileImg';
 import useAuth from '@/hooks/useAuth';
-import { useSetRecoilState } from 'recoil';
-import { userState } from '@/atom/atom';
 import useUserDetailQuery from '@/queries/user/useUserDetailQuery';
 
 const Header: FC = () => {
   const [menuOpen, setMenuOpen] = useState(false);
   const { logout, isLogin } = useAuth();
-  const setUser = useSetRecoilState(userState);
-  const data = useUserDetailQuery({
-    onSuccess: (res) => {
-      const profileUrl = res?.profileUrl;
-      setUser((prev) => ({ ...prev, profileUrl: profileUrl }));
-    },
-  });
+  const data = useUserDetailQuery();
 
   const onClickLogout = () => {
     logout();

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -9,7 +9,7 @@ import useUserDetailQuery from '@/queries/user/useUserDetailQuery';
 const Header: FC = () => {
   const [menuOpen, setMenuOpen] = useState(false);
   const { logout, isLogin } = useAuth();
-  const data = useUserDetailQuery();
+  const { data } = useUserDetailQuery();
 
   const onClickLogout = () => {
     logout();
@@ -47,7 +47,7 @@ const Header: FC = () => {
             {isLogin ? (
               <>
                 <div onClick={onClickMenuOpen}>
-                  <UserProfileImg src={data.data?.profileUrl} />
+                  <UserProfileImg src={data?.profileUrl} />
                 </div>
                 {menuOpen && (
                   <HeaderProfile onClickLogout={onClickLogout} onClickMenu={onClickMenuOpen} menuOpen={menuOpen} />

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,17 +1,23 @@
 import Button from '@/components/common/Button';
-import { getUserById } from '@/api/auth/authAPI';
 import { type FC, useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
 import { Link } from 'react-router-dom';
 import HeaderProfile from '@/components/common/HeaderProfile';
 import UserProfileImg from '@/components/common/UserProfileImg';
 import useAuth from '@/hooks/useAuth';
+import { useSetRecoilState } from 'recoil';
+import { userState } from '@/atom/atom';
+import useUserDetailQuery from '@/queries/user/useUserDetailQuery';
 
 const Header: FC = () => {
   const [menuOpen, setMenuOpen] = useState(false);
-  const { logout, isLogin, userId } = useAuth();
-
-  const { data } = useQuery(['user', userId], () => getUserById(Number(userId)));
+  const { logout, isLogin } = useAuth();
+  const setUser = useSetRecoilState(userState);
+  const data = useUserDetailQuery({
+    onSuccess: (res) => {
+      const profileUrl = res?.profileUrl;
+      setUser((prev) => ({ ...prev, profileUrl: profileUrl }));
+    },
+  });
 
   const onClickLogout = () => {
     logout();
@@ -49,7 +55,7 @@ const Header: FC = () => {
             {isLogin ? (
               <>
                 <div onClick={onClickMenuOpen}>
-                  <UserProfileImg src={data?.data.profileUrl} />
+                  <UserProfileImg src={data.data?.profileUrl} />
                 </div>
                 {menuOpen && (
                   <HeaderProfile onClickLogout={onClickLogout} onClickMenu={onClickMenuOpen} menuOpen={menuOpen} />

--- a/src/components/main/Search/Search.tsx
+++ b/src/components/main/Search/Search.tsx
@@ -6,12 +6,12 @@ interface Props {
 }
 
 const categoryOption: SelectOption[] = [
-  { label: '분야', value: '', id: 1 },
-  { label: '프론트엔드', value: 'frontend', id: 2 },
-  { label: '백엔드', value: 'backend', id: 3 },
-  { label: '디자인', value: 'design', id: 4 },
-  { label: '기획', value: 'plan', id: 5 },
-  { label: '기타', value: 'other', id: 6 },
+  { label: '분야', value: '' },
+  { label: '프론트엔드', value: 'frontend' },
+  { label: '백엔드', value: 'backend' },
+  { label: '디자인', value: 'design' },
+  { label: '기획', value: 'plan' },
+  { label: '기타', value: 'other' },
 ];
 
 // const placeOption: SelectOption[] = [
@@ -27,10 +27,10 @@ const categoryOption: SelectOption[] = [
 // ];
 
 const arrayOption: SelectOption[] = [
-  { label: '최신순', value: 'latest', id: 1 },
-  { label: '인기순', value: 'likes', id: 2 },
-  { label: '마감임박순', value: 'deadline', id: 3 },
-  { label: '조회수순', value: 'views', id: 4 },
+  { label: '최신순', value: 'latest' },
+  { label: '인기순', value: 'likes' },
+  { label: '마감임박순', value: 'deadline' },
+  { label: '조회수순', value: 'views' },
 ];
 
 const Search = ({ onChangeCategory, onChangeSort, onChange }: Props) => {

--- a/src/components/modal/ProfileEditModal.tsx
+++ b/src/components/modal/ProfileEditModal.tsx
@@ -6,6 +6,8 @@ import { useMutation } from '@tanstack/react-query';
 import axios from 'axios';
 import UserProfileImg from '@/components/common/UserProfileImg';
 import useAuth from '@/hooks/useAuth';
+import { useSetRecoilState } from 'recoil';
+import { userState } from '@/atom/atom';
 
 interface Props {
   onClose: () => void;
@@ -15,10 +17,13 @@ interface Props {
 const ProfileEditModal: FC<Props> = ({ onClose, src }: Props) => {
   const inputRef = useRef<HTMLInputElement | null>(null);
   const { userId } = useAuth();
+  const setUser = useSetRecoilState(userState);
 
   const { mutate: patchProfileImg } = useMutation(patchProfileImage, {
-    onSuccess: () => {
+    onSuccess: (res) => {
       alert('수정 완료');
+      const profileUrl = res?.data?.profileUrl;
+      setUser((prev) => ({ ...prev, profileUrl: profileUrl }));
     },
     onError: (err) => {
       if (axios.isAxiosError(err)) {

--- a/src/components/modal/ProfileEditModal.tsx
+++ b/src/components/modal/ProfileEditModal.tsx
@@ -23,7 +23,9 @@ const ProfileEditModal: FC<Props> = ({ onClose, src }: Props) => {
     onSuccess: (res) => {
       alert('수정 완료');
       const profileUrl = res?.data?.profileUrl;
-      setUser((prev) => ({ ...prev, profileUrl: profileUrl }));
+      setUser((prev) => {
+        return prev ? { ...prev, profileUrl } : prev;
+      });
     },
     onError: (err) => {
       if (axios.isAxiosError(err)) {

--- a/src/components/modal/ProfileEditModal.tsx
+++ b/src/components/modal/ProfileEditModal.tsx
@@ -75,7 +75,7 @@ const ProfileEditModal: FC<Props> = ({ onClose, src }: Props) => {
     <div className="profile-edit-modal-container">
       <div className="profile-edit-modal-content">
         <div className="profile-title">
-          <p>프로필 사진 등록</p>
+          <p>프로필 사진 업로드</p>
           <div />
           <button onClick={onClose}>X</button>
         </div>

--- a/src/components/mypage/UserProfile/index.scss
+++ b/src/components/mypage/UserProfile/index.scss
@@ -27,6 +27,11 @@
       right: 10px;
       border: 3px solid white;
       cursor: pointer;
+      color: white;
+      font-size: 20px;
+      display: flex;
+      justify-content: center;
+      align-items: center;
     }
   }
 }

--- a/src/components/mypage/UserProfile/index.tsx
+++ b/src/components/mypage/UserProfile/index.tsx
@@ -13,7 +13,9 @@ const UserProfile: FC<Props> = ({ src, name, onClick }) => {
     <div className="proflie">
       <div className="imgContainer">
         <UserProfileImg src={src} />
-        <i className="icon-pencil icon" onClick={onClick} />
+        <button onClick={onClick}>
+          <i className="icon-pencil icon" />
+        </button>
       </div>
       <p>{name}</p>
     </div>

--- a/src/components/mypage/UserProfile/index.tsx
+++ b/src/components/mypage/UserProfile/index.tsx
@@ -8,20 +8,12 @@ interface Props {
   onClick: () => void;
 }
 
-const style = {
-  color: 'white',
-  fontSize: '20px',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-};
-
 const UserProfile: FC<Props> = ({ src, name, onClick }) => {
   return (
     <div className="proflie">
       <div className="imgContainer">
         <UserProfileImg src={src} />
-        <i className="icon-pencil icon" onClick={onClick} style={style} />
+        <i className="icon-pencil icon" onClick={onClick} />
       </div>
       <p>{name}</p>
     </div>

--- a/src/components/study/studySchedule/StudySchedule.tsx
+++ b/src/components/study/studySchedule/StudySchedule.tsx
@@ -4,15 +4,14 @@ import Calendar from '@/components/study/studySchedule/Calendar';
 import { useParams } from 'react-router-dom';
 import TodoList from '@/components/study/studySchedule/todoList/TodoList';
 import AddUserComment, { CommentFormValue } from '@/components/common/AddUserComment';
-import { useQuery } from '@tanstack/react-query';
-import { getUserById } from '@/api/auth/authAPI';
 import CommentBox from '@/components/study/studySchedule/comment/CommentBox';
-import useAuth from '@/hooks/useAuth';
 import { formatDate } from '@/utils/dateForm';
 import useStudyCommentsQuery from '@/queries/study/useStudyCommentsQuery';
 import useDeleteStudyCommentMutation from '@/queries/study/useDeleteStudyCommentMutation';
 import usePatchStudyCommentMutation from '@/queries/study/usePatchStudyCommentMutation';
 import usePostStudyCommentMutation from '@/queries/study/usePostStudyCommentMutation';
+import { useRecoilValue } from 'recoil';
+import { userState } from '@/atom/atom';
 
 interface Props {
   startDate?: string;
@@ -22,16 +21,11 @@ interface Props {
 const StudySchedule: FC<Props> = ({ startDate, endDate }) => {
   const [selectedDate, setSelectedDate] = useState<Date>(new Date());
   const { studyId } = useParams();
-  const { userId } = useAuth();
   const { data: comment } = useStudyCommentsQuery(Number(studyId), selectedDate);
   const onDeleteComment = useDeleteStudyCommentMutation();
   const onPatchComment = usePatchStudyCommentMutation();
   const onPostComment = usePostStudyCommentMutation();
-
-  const { data } = useQuery({
-    queryFn: () => getUserById(Number(userId)),
-    queryKey: ['user', userId],
-  });
+  const user = useRecoilValue(userState);
 
   const onSubmitPostComment = (data: CommentFormValue) => {
     const taskDate = formatDate(selectedDate, 'yyyy-MM-dd');
@@ -71,7 +65,7 @@ const StudySchedule: FC<Props> = ({ startDate, endDate }) => {
             <Calendar curDate={selectedDate} onDateChange={handleDateChange} startDate={startDate} endDate={endDate} />
             <TodoList selectedDate={selectedDate} studyId={studyId} />
           </div>
-          <AddUserComment profileUrl={data?.data.profileUrl} onSubmitPostComment={onSubmitPostComment} />
+          <AddUserComment profileUrl={user.profileUrl} onSubmitPostComment={onSubmitPostComment} />
           <CommentBox
             comments={comment ?? []}
             onDeleteComment={handleDeleteComment}

--- a/src/components/study/studySchedule/StudySchedule.tsx
+++ b/src/components/study/studySchedule/StudySchedule.tsx
@@ -10,8 +10,6 @@ import useStudyCommentsQuery from '@/queries/study/useStudyCommentsQuery';
 import useDeleteStudyCommentMutation from '@/queries/study/useDeleteStudyCommentMutation';
 import usePatchStudyCommentMutation from '@/queries/study/usePatchStudyCommentMutation';
 import usePostStudyCommentMutation from '@/queries/study/usePostStudyCommentMutation';
-import { useRecoilValue } from 'recoil';
-import { userState } from '@/atom/atom';
 
 interface Props {
   startDate?: string;
@@ -25,7 +23,6 @@ const StudySchedule: FC<Props> = ({ startDate, endDate }) => {
   const onDeleteComment = useDeleteStudyCommentMutation();
   const onPatchComment = usePatchStudyCommentMutation();
   const onPostComment = usePostStudyCommentMutation();
-  const user = useRecoilValue(userState);
 
   const onSubmitPostComment = (data: CommentFormValue) => {
     const taskDate = formatDate(selectedDate, 'yyyy-MM-dd');
@@ -65,7 +62,7 @@ const StudySchedule: FC<Props> = ({ startDate, endDate }) => {
             <Calendar curDate={selectedDate} onDateChange={handleDateChange} startDate={startDate} endDate={endDate} />
             <TodoList selectedDate={selectedDate} studyId={studyId} />
           </div>
-          <AddUserComment profileUrl={user.profileUrl} onSubmitPostComment={onSubmitPostComment} />
+          <AddUserComment onSubmitPostComment={onSubmitPostComment} />
           <CommentBox
             comments={comment ?? []}
             onDeleteComment={handleDeleteComment}

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -1,0 +1,10 @@
+import { userState } from '@/atom/atom';
+import { useRecoilValue } from 'recoil';
+
+const useUser = () => {
+  const user = useRecoilValue(userState);
+
+  return { userProfile: user.profileUrl, userId: user?.userId };
+};
+
+export default useUser;

--- a/src/pages/recruit/Detail.tsx
+++ b/src/pages/recruit/Detail.tsx
@@ -10,11 +10,12 @@ import useRecruitDetailQuery from '@/queries/recruit/useRecruitDetailQuery';
 import usePostRecruitLikesMutation from '@/queries/recruit/usePostRecruitLikesMutation';
 import useStudyDetailQuery from '@/queries/study/useStudyDetailQuery';
 import usePostStudyGroupMutation from '@/queries/study/usePostStudyGroupMutation';
-import useUserDetailQuery from '@/queries/user/useUserDetailQuery';
 import { type FC, useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import classNames from 'classnames';
 import changeToHtml from '@/utils/changeToHtml';
+import { useRecoilValue } from 'recoil';
+import { userState } from '@/atom/atom';
 
 const RecruitDetail: FC = () => {
   const { studyId } = useParams();
@@ -24,7 +25,6 @@ const RecruitDetail: FC = () => {
     },
   });
   const { data: recruit } = useRecruitDetailQuery(Number(studyId));
-  const { data: user } = useUserDetailQuery();
   const { data: recruitComment } = useRecruitCommentQuery(Number(studyId));
   const [isClicked, setIsClicked] = useState(false);
   const onDeleteComment = useDeleteRecruitCommentMutation();
@@ -37,6 +37,7 @@ const RecruitDetail: FC = () => {
     },
   });
   const navigate = useNavigate();
+  const user = useRecoilValue(userState);
 
   useEffect(() => {
     if (study?.checkLikes !== undefined && study.checkLikes !== null) setIsClicked(study.checkLikes);
@@ -104,7 +105,7 @@ const RecruitDetail: FC = () => {
                 <div dangerouslySetInnerHTML={{ __html: ruleHTML ?? '' }} />
               </div>
             </div>
-            <AddUserComment onSubmitPostComment={onSubmitPostComment} profileUrl={user?.profileUrl} />
+            <AddUserComment onSubmitPostComment={onSubmitPostComment} profileUrl={user.profileUrl} />
             <CommentBox
               comments={recruitComment ?? []}
               onDeleteComment={onDeleteComment}

--- a/src/pages/recruit/Detail.tsx
+++ b/src/pages/recruit/Detail.tsx
@@ -14,8 +14,6 @@ import { type FC, useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import classNames from 'classnames';
 import changeToHtml from '@/utils/changeToHtml';
-import { useRecoilValue } from 'recoil';
-import { userState } from '@/atom/atom';
 
 const RecruitDetail: FC = () => {
   const { studyId } = useParams();
@@ -37,7 +35,6 @@ const RecruitDetail: FC = () => {
     },
   });
   const navigate = useNavigate();
-  const user = useRecoilValue(userState);
 
   useEffect(() => {
     if (study?.checkLikes !== undefined && study.checkLikes !== null) setIsClicked(study.checkLikes);
@@ -105,7 +102,7 @@ const RecruitDetail: FC = () => {
                 <div dangerouslySetInnerHTML={{ __html: ruleHTML ?? '' }} />
               </div>
             </div>
-            <AddUserComment onSubmitPostComment={onSubmitPostComment} profileUrl={user.profileUrl} />
+            <AddUserComment onSubmitPostComment={onSubmitPostComment} />
             <CommentBox
               comments={recruitComment ?? []}
               onDeleteComment={onDeleteComment}

--- a/src/pages/user/MyPage.tsx
+++ b/src/pages/user/MyPage.tsx
@@ -1,12 +1,12 @@
 import { type FC, useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
-import { getUserById } from '@/api/auth/authAPI';
 import ProfileEditModal from '@/components/modal/ProfileEditModal';
 import './myPage.scss';
 import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 import classNames from 'classnames';
 import UserProfile from '@/components/mypage/UserProfile';
-import useAuth from '@/hooks/useAuth';
+import { useRecoilValue } from 'recoil';
+import { userState } from '@/atom/atom';
+import useUserDetailQuery from '@/queries/user/useUserDetailQuery';
 
 const rootPath = '/user/mypage';
 
@@ -21,10 +21,8 @@ const tabs = [
 const MyPage: FC = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const { pathname } = useLocation();
-
-  const { userId } = useAuth();
-
-  const { data } = useQuery(['user', userId], () => getUserById(Number(userId)));
+  const user = useRecoilValue(userState);
+  const { data } = useUserDetailQuery();
 
   const onClickOpenModal = () => {
     setIsModalOpen(!isModalOpen);
@@ -33,11 +31,11 @@ const MyPage: FC = () => {
 
   return (
     <>
-      {isModalOpen && <ProfileEditModal onClose={onClickOpenModal} src={data?.data.profileUrl} />}
+      {isModalOpen && <ProfileEditModal onClose={onClickOpenModal} src={user.profileUrl} />}
       <div className="container box">
         <div className="row">
           <div className="col-lg-3 column">
-            <UserProfile src={data?.data.profileUrl} name={data?.data.userName ?? ''} onClick={onClickOpenModal} />
+            <UserProfile src={user.profileUrl} name={data?.userName ?? ''} onClick={onClickOpenModal} />
             <ul className="tab-container">
               {tabs.map((tab) => (
                 <li

--- a/src/pages/user/MyPage.tsx
+++ b/src/pages/user/MyPage.tsx
@@ -4,9 +4,8 @@ import './myPage.scss';
 import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 import classNames from 'classnames';
 import UserProfile from '@/components/mypage/UserProfile';
-import { useRecoilValue } from 'recoil';
-import { userState } from '@/atom/atom';
 import useUserDetailQuery from '@/queries/user/useUserDetailQuery';
+import useUser from '@/hooks/useUser';
 
 const rootPath = '/user/mypage';
 
@@ -21,8 +20,8 @@ const tabs = [
 const MyPage: FC = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const { pathname } = useLocation();
-  const user = useRecoilValue(userState);
   const { data } = useUserDetailQuery();
+  const { userProfile } = useUser();
 
   const onClickOpenModal = () => {
     setIsModalOpen(!isModalOpen);
@@ -31,11 +30,11 @@ const MyPage: FC = () => {
 
   return (
     <>
-      {isModalOpen && <ProfileEditModal onClose={onClickOpenModal} src={user.profileUrl} />}
+      {isModalOpen && <ProfileEditModal onClose={onClickOpenModal} src={userProfile} />}
       <div className="container box">
         <div className="row">
           <div className="col-lg-3 column">
-            <UserProfile src={user.profileUrl} name={data?.userName ?? ''} onClick={onClickOpenModal} />
+            <UserProfile src={userProfile} name={data?.userName ?? ''} onClick={onClickOpenModal} />
             <ul className="tab-container">
               {tabs.map((tab) => (
                 <li

--- a/src/pages/user/UserInfo.tsx
+++ b/src/pages/user/UserInfo.tsx
@@ -1,12 +1,13 @@
-import { deleteUser, getUserById } from '@/api/auth/authAPI';
+import { deleteUser } from '@/api/auth/authAPI';
 import ConfirmModal from '@/components/modal/ConfirmModal';
 import BasicInfo from '@/components/mypage/UserInfo/BasicInfo';
 import ExtraInfo from '@/components/mypage/UserInfo/ExtraInfo';
 import PasswordInfo from '@/components/mypage/UserInfo/PasswordInfo';
 import { StorageKeys } from '@/constants/storageKeys';
 import useAuth from '@/hooks/useAuth';
+import useUserDetailQuery from '@/queries/user/useUserDetailQuery';
 import { initAuthStorage } from '@/utils';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import axios from 'axios';
 import { type FC, useState } from 'react';
 import './userInfo.scss';
@@ -15,14 +16,12 @@ const UserInfo: FC = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const { userId } = useAuth();
   const oauth = localStorage.getItem(StorageKeys.OAuth);
+  const { data } = useUserDetailQuery();
 
   if (!userId) {
     throw new Error('no user');
   }
 
-  const { data } = useQuery(['user', userId], () => getUserById(Number(userId)), {
-    select: (data) => data.data,
-  });
   const userName = data?.userName;
   const email = data?.email;
   const field = data?.field;

--- a/src/queries/user/useUserDetailQuery.ts
+++ b/src/queries/user/useUserDetailQuery.ts
@@ -1,18 +1,18 @@
 import { getUserById } from '@/api/auth/authAPI';
-import type { GetUserRes } from '@/api/auth/types';
+import { userState } from '@/atom/atom';
 import useAuth from '@/hooks/useAuth';
 import { useQuery } from '@tanstack/react-query';
+import { useSetRecoilState } from 'recoil';
 
-type QueryOption = {
-  onSuccess: (data: GetUserRes) => void;
-};
-
-const useUserDetailQuery = (options?: QueryOption) => {
+const useUserDetailQuery = () => {
   const { userId } = useAuth();
+  const setUser = useSetRecoilState(userState);
 
   return useQuery(['user', userId], () => getUserById(Number(userId)), {
     select: ({ data }) => data,
-    ...options,
+    onSuccess: (res) => {
+      setUser((prev) => ({ ...prev, userId: res.userId, profileUrl: res.profileUrl }));
+    },
   });
 };
 

--- a/src/queries/user/useUserDetailQuery.ts
+++ b/src/queries/user/useUserDetailQuery.ts
@@ -1,12 +1,18 @@
 import { getUserById } from '@/api/auth/authAPI';
+import type { GetUserRes } from '@/api/auth/types';
 import useAuth from '@/hooks/useAuth';
 import { useQuery } from '@tanstack/react-query';
 
-const useUserDetailQuery = () => {
+type QueryOption = {
+  onSuccess: (data: GetUserRes) => void;
+};
+
+const useUserDetailQuery = (options?: QueryOption) => {
   const { userId } = useAuth();
 
   return useQuery(['user', userId], () => getUserById(Number(userId)), {
     select: ({ data }) => data,
+    ...options,
   });
 };
 


### PR DESCRIPTION
# 이 풀리퀘스트는 다음과 같습니다

## 배경

- 사용자 프로필 사진도 atom에 저장해서 사용하는 방향으로 수정했습니다.

## 작업내용

- 사용자 프로필 사진이 필요할 때 매번 유저 조회 요청을 보내는 것이 불필요하다고 생각하여 로그인을 했을 때, 프로필 사진을 변경했을 때 atom에 프로필 사진을 저장하여 사용했습니다. 

## 리뷰어에게

- 일단은 관련 부분 쿼리만 수정하였습니다. 
- Search 파일에서 에러가 발생해 id값을 지웠습니다. 
