### PR TITLE
[Feat] 스터디 상세 페이지 이동 추가

### DIFF
--- a/src/api/recruit/recruitAPI.ts
+++ b/src/api/recruit/recruitAPI.ts
@@ -2,6 +2,7 @@ import axiosInstance from '@/api/axiosInstance';
 import type {
   CommentRes,
   GetRecruitRes,
+  PatchRecruitReq,
   PostRecruitCommentReq,
   PostRecruitReq,
   Recruit,
@@ -62,3 +63,8 @@ export const deleteRecruitComment = (offerCommentId: number) =>
   axiosInstance.delete(`/api/offer-comment/${offerCommentId}`);
 
 export const postRecruitLikes = (studyId: number) => axiosInstance.post(`/api/study/${studyId}/likes`);
+
+export const patchRecruit = ({ offerId, ...body }: PatchRecruitReq) =>
+  axiosInstance.patch(`/api/offer/${offerId}`, body);
+
+export const deleteRecruit = (offerId: number) => axiosInstance.delete(`/api/offer/${offerId}`);

--- a/src/api/recruit/recruitTypes.ts
+++ b/src/api/recruit/recruitTypes.ts
@@ -51,3 +51,10 @@ export interface CommentRes {
   userName: string;
   studyCommentId?: number;
 }
+
+export interface RecruitFormValue {
+  offerIntro: string;
+  offerRule: string;
+}
+
+export type PatchRecruitReq = GetRecruitRes;

--- a/src/components/study/adminMode/Management.tsx
+++ b/src/components/study/adminMode/Management.tsx
@@ -4,7 +4,11 @@ import { Link, useParams } from 'react-router-dom';
 
 const Management: FC = () => {
   const { studyId } = useParams();
-  const data = useStudyDetailQuery(Number(studyId));
+  const { data, isError } = useStudyDetailQuery(Number(studyId));
+
+  if (isError) {
+    return <div>에러 발생!!</div>;
+  }
 
   return (
     <div className="notice-container">
@@ -14,7 +18,7 @@ const Management: FC = () => {
           <p>구인 글 관리</p>
           <div className="sub-content-bundle">
             <Link to={`/recruit/detail/${studyId}`}>
-              <span>{data.data?.title}</span>
+              <span>{data?.title}</span>
             </Link>
             <div className="notice-button-container">
               <Link to={`/recruit/edit/${studyId}`}>

--- a/src/components/study/adminMode/Management.tsx
+++ b/src/components/study/adminMode/Management.tsx
@@ -1,8 +1,10 @@
+import useStudyDetailQuery from '@/queries/study/useStudyDetailQuery';
 import type { FC } from 'react';
 import { Link, useParams } from 'react-router-dom';
 
 const Management: FC = () => {
   const { studyId } = useParams();
+  const data = useStudyDetailQuery(Number(studyId));
 
   return (
     <div className="notice-container">
@@ -12,7 +14,7 @@ const Management: FC = () => {
           <p>구인 글 관리</p>
           <div className="sub-content-bundle">
             <Link to={`/recruit/detail/${studyId}`}>
-              <span>스터디 만들거야 모집중</span>
+              <span>{data.data?.title}</span>
             </Link>
             <div className="notice-button-container">
               <Link to={`/recruit/edit/${studyId}`}>

--- a/src/components/study/adminMode/Management.tsx
+++ b/src/components/study/adminMode/Management.tsx
@@ -1,6 +1,9 @@
 import type { FC } from 'react';
+import { Link, useParams } from 'react-router-dom';
 
 const Management: FC = () => {
+  const { studyId } = useParams();
+
   return (
     <div className="notice-container">
       <p className="notice-title">스터디 운영 관리</p>
@@ -8,9 +11,13 @@ const Management: FC = () => {
         <div className="sub-content">
           <p>구인 글 관리</p>
           <div className="sub-content-bundle">
-            <span>스터디 만들거야 모집중</span>
+            <Link to={`/recruit/detail/${studyId}`}>
+              <span>스터디 만들거야 모집중</span>
+            </Link>
             <div className="notice-button-container">
-              <button>수정</button>
+              <Link to={`/recruit/edit/${studyId}`}>
+                <button>수정</button>
+              </Link>
               <button className="notice-delete">삭제</button>
             </div>
           </div>

--- a/src/components/study/adminMode/Management.tsx
+++ b/src/components/study/adminMode/Management.tsx
@@ -1,10 +1,18 @@
+import useDeleteRecruitMutation from '@/queries/recruit/useDeleteRecruitMutation';
+import useRecruitDetailQuery from '@/queries/recruit/useRecruitDetailQuery';
 import useStudyDetailQuery from '@/queries/study/useStudyDetailQuery';
 import type { FC } from 'react';
 import { Link, useParams } from 'react-router-dom';
 
 const Management: FC = () => {
   const { studyId } = useParams();
-  const { data, isError } = useStudyDetailQuery(Number(studyId));
+  const { data: study, isError } = useStudyDetailQuery(Number(studyId));
+  const { data: recruit } = useRecruitDetailQuery(Number(studyId));
+  const ondeleteRecruit = useDeleteRecruitMutation();
+
+  const onClickDeleteRecruit = () => {
+    ondeleteRecruit.mutate(Number(recruit?.offerId));
+  };
 
   if (isError) {
     return <div>에러 발생!!</div>;
@@ -18,13 +26,15 @@ const Management: FC = () => {
           <p>구인 글 관리</p>
           <div className="sub-content-bundle">
             <Link to={`/recruit/detail/${studyId}`}>
-              <span>{data?.title}</span>
+              <span>{study?.title}</span>
             </Link>
             <div className="notice-button-container">
               <Link to={`/recruit/edit/${studyId}`}>
                 <button>수정</button>
               </Link>
-              <button className="notice-delete">삭제</button>
+              <button className="notice-delete" onClick={onClickDeleteRecruit}>
+                삭제
+              </button>
             </div>
           </div>
         </div>

--- a/src/pages/recruit/Create.tsx
+++ b/src/pages/recruit/Create.tsx
@@ -8,11 +8,7 @@ import { useMutation } from '@tanstack/react-query';
 import type { FC } from 'react';
 import { type SubmitHandler, useForm } from 'react-hook-form';
 import { useNavigate, useParams } from 'react-router-dom';
-
-interface RecruitFormValue {
-  offerIntro: string;
-  offerRule: string;
-}
+import type { RecruitFormValue } from '@/api/recruit/recruitTypes';
 
 const RecruitCreate: FC = () => {
   const { studyId } = useParams();
@@ -65,7 +61,7 @@ const RecruitCreate: FC = () => {
               {errors.offerRule && <p className="err-msg">{errors.offerRule.message?.toString()}</p>}
             </div>
             <div className="button-area">
-              <Button size="large" color="gray" outline>
+              <Button size="large" color="gray" outline onClick={onClickGoBack} type="button">
                 취소
               </Button>
               <Button size="large" type="submit">

--- a/src/pages/recruit/Edit.tsx
+++ b/src/pages/recruit/Edit.tsx
@@ -1,11 +1,85 @@
+import type { RecruitFormValue } from '@/api/recruit/recruitTypes';
+import Button from '@/components/common/Button';
+import StudyDetailIntro from '@/components/common/StudyDetailIntro';
+import { recruitSchema } from '@/constants/schema/recruitSchema';
+import usePatchRecruitMutation from '@/queries/recruit/usePatchRecruitMutation';
+import useRecruitDetailQuery from '@/queries/recruit/useRecruitDetailQuery';
+import useStudyDetailQuery from '@/queries/study/useStudyDetailQuery';
+import changeToPlainText from '@/utils/changeToPlainText';
+import { yupResolver } from '@hookform/resolvers/yup';
 import type { FC } from 'react';
+import { type SubmitHandler, useForm } from 'react-hook-form';
+import { useNavigate, useParams } from 'react-router-dom';
 
 const RecruitEdit: FC = () => {
+  const { studyId } = useParams();
+  const navigate = useNavigate();
+  const { data: study } = useStudyDetailQuery(Number(studyId));
+  const { data: recruit } = useRecruitDetailQuery(Number(studyId));
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<RecruitFormValue>({ resolver: yupResolver(recruitSchema) });
+  const patchRecruit = usePatchRecruitMutation(Number(studyId));
+
+  const onClickGoBack = () => {
+    navigate(-1);
+  };
+
+  const onSumbit: SubmitHandler<RecruitFormValue> = (data) => {
+    patchRecruit.mutate({ offerId: Number(recruit?.offerId), ...data });
+  };
+
+  const introHTML = changeToPlainText(recruit?.offerIntro);
+  const ruleHTML = changeToPlainText(recruit?.offerRule);
+
   return (
     <div className="container">
       <div className="row">
         <div className="col-lg-12">
-          <div>구인 글 수정 페이지</div>
+          <div className="title-area">
+            <button onClick={onClickGoBack}>
+              <i className="icon-arrow-left" />
+            </button>
+            <p>구인 글 수정하기</p>
+            <div />
+          </div>
+          <StudyDetailIntro detailData={study} />
+
+          <form className="add-recruit-box" onSubmit={handleSubmit(onSumbit)} id="recruit">
+            <div className="recruit-intro">
+              <p>스터디 소개</p>
+              <textarea
+                placeholder="내용을 작성해주세요."
+                required
+                form="recruit"
+                {...register('offerIntro')}
+                defaultValue={introHTML}
+              />
+              {errors.offerIntro && <p className="err-msg">{errors.offerIntro.message}</p>}
+            </div>
+
+            <div className="recruit-rule">
+              <p>스터디 규칙</p>
+              <textarea
+                placeholder="내용을 작성해주세요."
+                required
+                form="recruit"
+                {...register('offerRule')}
+                defaultValue={ruleHTML}
+              />
+              {errors.offerRule && <p className="err-msg">{errors.offerRule.message}</p>}
+            </div>
+            <div className="button-area">
+              <Button size="large" color="gray" outline onClick={onClickGoBack} type="button">
+                취소
+              </Button>
+              <Button size="large" type="submit">
+                저장
+              </Button>
+            </div>
+          </form>
         </div>
       </div>
     </div>

--- a/src/pages/recruit/Edit.tsx
+++ b/src/pages/recruit/Edit.tsx
@@ -1,7 +1,15 @@
 import type { FC } from 'react';
 
 const RecruitEdit: FC = () => {
-  return <div>구인 글 edit</div>;
+  return (
+    <div className="container">
+      <div className="row">
+        <div className="col-lg-12">
+          <div>구인 글 수정 페이지</div>
+        </div>
+      </div>
+    </div>
+  );
 };
 
 export default RecruitEdit;

--- a/src/pages/study/Detail.tsx
+++ b/src/pages/study/Detail.tsx
@@ -13,7 +13,6 @@ import './detail.scss';
 const StudyDetail: FC = () => {
   const [currentTab, setCurrentTab] = useState(0);
   const [isMapModalOpen, setIsMapModalOpen] = useState(false);
-
   const { studyId } = useParams();
   const { userId } = useAuth();
   const { data, isLoading, isError } = useQuery({

--- a/src/pages/user/UserLikeStudy.tsx
+++ b/src/pages/user/UserLikeStudy.tsx
@@ -40,7 +40,7 @@ const UserLikeStudy = () => {
         ) : (
           data.data.map(({ studyId, endDate, startDate, title, stack }) => {
             const studyData = { endDate, startDate, title, stack, studyId };
-            return <StudyBlock key={studyId} studyData={studyData} isRecruit={selectOption === 'before_recruitment'} />;
+            return <StudyBlock key={studyId} studyData={studyData} studyRoute="recruit" />;
           })
         )}
       </div>

--- a/src/pages/user/UserStudy.tsx
+++ b/src/pages/user/UserStudy.tsx
@@ -29,7 +29,7 @@ const UserStudy: FC = () => {
   if (isError) return <div>에러남</div>;
 
   const maxPostPage = data?.pageInfo?.totalPages ?? 0;
-  const studyRoute = selectOption === ('ongoing' || 'end') ? 'detail' : 'recruit';
+  const studyRoute = selectOption === ('before_recruitment' && 'recruiting') ? 'recruit' : 'detail';
 
   return (
     <div className="study-container">

--- a/src/pages/user/UserStudy.tsx
+++ b/src/pages/user/UserStudy.tsx
@@ -29,7 +29,7 @@ const UserStudy: FC = () => {
   if (isError) return <div>에러남</div>;
 
   const maxPostPage = data?.pageInfo?.totalPages ?? 0;
-  const studyRoute = selectOption === ('before_recruitment' && 'recruiting') ? 'recruit' : 'detail';
+  const studyRoute = selectOption === 'before_recruitment' || selectOption === 'recruiting' ? 'recruit' : 'detail';
 
   return (
     <div className="study-container">

--- a/src/queries/recruit/useDeleteRecruitMutation.ts
+++ b/src/queries/recruit/useDeleteRecruitMutation.ts
@@ -1,0 +1,16 @@
+import { deleteRecruit } from '@/api/recruit/recruitAPI';
+import { useMutation } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+
+const useDeleteRecruitMutation = () => {
+  const navigate = useNavigate();
+
+  return useMutation(deleteRecruit, {
+    onSuccess: () => {
+      alert('삭제되었습니다!');
+      navigate('/');
+    },
+  });
+};
+
+export default useDeleteRecruitMutation;

--- a/src/queries/recruit/usePatchRecruitMutation.ts
+++ b/src/queries/recruit/usePatchRecruitMutation.ts
@@ -1,0 +1,16 @@
+import { patchRecruit } from '@/api/recruit/recruitAPI';
+import { useMutation } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+
+const usePatchRecruitMutation = (studyId: number) => {
+  const navigate = useNavigate();
+
+  return useMutation(patchRecruit, {
+    onSuccess: () => {
+      alert('수정되었습니다!');
+      navigate(`/recruit/detail/${studyId}`);
+    },
+  });
+};
+
+export default usePatchRecruitMutation;

--- a/src/routes/RoutesSetup.tsx
+++ b/src/routes/RoutesSetup.tsx
@@ -46,7 +46,7 @@ export const RoutesSetup = () => {
       <Route path="/recruit">
         <Route path="detail/:studyId" element={<RecruitDetail />} />
         <Route path="create/:studyId" element={<RecruitCreate />} />
-        <Route path="edit" element={<RecruitEdit />} />
+        <Route path="edit/:studyId" element={<RecruitEdit />} />
       </Route>
 
       {/* 개발 후 삭제할 샘플 페이지 */}

--- a/src/utils/changeToPlainText.ts
+++ b/src/utils/changeToPlainText.ts
@@ -1,0 +1,5 @@
+const changeToPlainText = (text?: string) => {
+  return text?.replace(/ /g, '\u00A0');
+};
+
+export default changeToPlainText;


### PR DESCRIPTION
# 이 풀리퀘스트는 다음과 같습니다

## 배경

- 관리자모드에서 이동할 수 있는 페이지를 추가했습니다.

## 작업내용

- 관리자 모드에서 스터디 제목을 클릭하면 구인글 상세 페이지로 이동합니다.
- 수정 버튼을 누르면 구인글 수정 페이지로 이동합니다. 

## 리뷰어에게

- 구인글 수정은 이후 올리겠습니다.
