### PR TITLE
fix:프로필 이미지 깨짐 해결

### DIFF
--- a/src/components/common/UserProfileImg.tsx
+++ b/src/components/common/UserProfileImg.tsx
@@ -5,10 +5,8 @@ interface Props {
   src?: string;
 }
 
-const UserProfileImg: FC<Props> = ({ src }: Props) => {
-  const imageSrc = src !== '' ? src : BASE_PROFILE_URL;
-
-  return <img src={imageSrc} alt="profileImg" />;
+const UserProfileImg: FC<Props> = ({ src }) => {
+  return <img src={src || BASE_PROFILE_URL} alt="profileImg" />;
 };
 
 export default UserProfileImg;

--- a/src/components/common/UserProfileImg.tsx
+++ b/src/components/common/UserProfileImg.tsx
@@ -6,7 +6,9 @@ interface Props {
 }
 
 const UserProfileImg: FC<Props> = ({ src }: Props) => {
-  return <img src={src ?? BASE_PROFILE_URL} alt="profileImg" />;
+  const imageSrc = src !== '' ? src : BASE_PROFILE_URL;
+
+  return <img src={imageSrc} alt="profileImg" />;
 };
 
 export default UserProfileImg;


### PR DESCRIPTION
# 이 풀리퀘스트는 다음과 같습니다

## 배경

## 작업내용

- 로그인 하지 않은 사용자는 프로필 이미지 초기값이 빈문자열이기 때문에 기본 사진이 보이지 않습니다. 그래서 조건문을 추가하여 빈문자열이 아닐때만 props로 받은 이미지 주소를 src로 사용하고, 빈문자열이라면 기본이미지로 수정했습니다.

## 리뷰어에게
