### PR TITLE
[Refactor] 프로필 이미지 미리보기 수정

### DIFF
--- a/src/components/modal/ProfileEditModal.tsx
+++ b/src/components/modal/ProfileEditModal.tsx
@@ -23,10 +23,13 @@ const ProfileEditModal: FC<Props> = ({ onClose, src }: Props) => {
       return;
     }
 
+    if (previewSrc) URL.revokeObjectURL(previewSrc);
+
     const file = event.target.files[0];
     setPreviewSrc(URL.createObjectURL(file));
     setProfileSrc(file);
   };
+
   const onClickPatchImage = () => {
     if (!userId || !profileSrc) return;
 
@@ -37,6 +40,8 @@ const ProfileEditModal: FC<Props> = ({ onClose, src }: Props) => {
 
   const onClickDeleteImage = () => {
     if (!userId) return;
+
+    if (previewSrc) URL.revokeObjectURL(previewSrc);
 
     const image = new FormData();
     image.append('image', '');

--- a/src/components/modal/ProfileEditModal.tsx
+++ b/src/components/modal/ProfileEditModal.tsx
@@ -1,13 +1,9 @@
 import Button from '@/components/common/Button';
 import { type FC, useRef, useCallback, useState } from 'react';
 import './profileEditModal.scss';
-import { patchProfileImage } from '@/api/auth/authAPI';
-import { useMutation } from '@tanstack/react-query';
-import axios from 'axios';
 import UserProfileImg from '@/components/common/UserProfileImg';
 import useAuth from '@/hooks/useAuth';
-import { useSetRecoilState } from 'recoil';
-import { userState } from '@/atom/atom';
+import usePatchProfileImgMutation from '@/queries/user/usePatchProfileImgMutation';
 
 interface Props {
   onClose: () => void;
@@ -17,32 +13,10 @@ interface Props {
 const ProfileEditModal: FC<Props> = ({ onClose, src }: Props) => {
   const inputRef = useRef<HTMLInputElement | null>(null);
   const { userId } = useAuth();
-  const setUser = useSetRecoilState(userState);
   const [previewSrc, setPreviewSrc] = useState(src);
   const [profileSrc, setProfileSrc] = useState<File | null>(null);
 
-  const { mutate: patchProfileImg } = useMutation(patchProfileImage, {
-    onSuccess: (res) => {
-      alert('수정 완료');
-      const profileUrl = res?.data?.profileUrl;
-      setUser((prev) => {
-        return prev ? { ...prev, profileUrl } : prev;
-      });
-      onClose();
-    },
-    onError: (err) => {
-      if (axios.isAxiosError(err)) {
-        const statusCode = err.response?.status;
-        const errorMessage = err.response?.data?.message;
-        if (statusCode === 400 && errorMessage === 'Max file size 2MB') {
-          alert('파일이 2MB를 초과하였습니다.');
-        }
-        if (statusCode === 400 && errorMessage === 'Invalid Values') {
-          alert('jpg/jpeg, png, gif 파일만 업로드 가능합니다.');
-        }
-      }
-    },
-  });
+  const { mutate: patchProfileImg } = usePatchProfileImgMutation(onClose);
 
   const onChangeImage = (event: React.ChangeEvent<HTMLInputElement>) => {
     if (!event.target.files) {

--- a/src/queries/user/usePatchProfileImgMutation.ts
+++ b/src/queries/user/usePatchProfileImgMutation.ts
@@ -1,0 +1,34 @@
+import { patchProfileImage } from '@/api/auth/authAPI';
+import { userState } from '@/atom/atom';
+import { useMutation } from '@tanstack/react-query';
+import axios from 'axios';
+import { useSetRecoilState } from 'recoil';
+
+const usePatchProfileImgMutation = (onClose: () => void) => {
+  const setUser = useSetRecoilState(userState);
+
+  return useMutation(patchProfileImage, {
+    onSuccess: (res) => {
+      alert('수정 완료');
+      const profileUrl = res?.data?.profileUrl;
+      setUser((prev) => {
+        return prev ? { ...prev, profileUrl } : prev;
+      });
+      onClose();
+    },
+    onError: (err) => {
+      if (axios.isAxiosError(err)) {
+        const statusCode = err.response?.status;
+        const errorMessage = err.response?.data?.message;
+        if (statusCode === 400 && errorMessage === 'Max file size 2MB') {
+          alert('파일이 2MB를 초과하였습니다.');
+        }
+        if (statusCode === 400 && errorMessage === 'Invalid Values') {
+          alert('jpg/jpeg, png, gif 파일만 업로드 가능합니다.');
+        }
+      }
+    },
+  });
+};
+
+export default usePatchProfileImgMutation;


### PR DESCRIPTION
# 이 풀리퀘스트는 다음과 같습니다

## 배경

- 프로필 변경 후 미리보기 기능 수정

## 작업내용

- URL.createObjectURL() 메서드를 사용하여 선택한 이미지를 미리 보여준 후 
- URL.revokeObjectURL() 메서드를 사용하여 다른 사진을 선택하거나 사진을 지울 때 생성된 URL을 폐기시키는 방법으로 수정했습니다. 

## 리뷰어에게
