### PR TITLE
[Refactor] 푸터 컨텐츠 길이에 맞게 하단 고정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,23 +7,28 @@ import Header from './components/common/Header';
 import Footer from './components/common/Footer';
 import { RoutesSetup } from './routes/RoutesSetup';
 import '@/styles/main.scss';
+import type { ReactNode } from 'react';
 
 const queryClient = new QueryClient();
 
+const AppProvider = ({ children }: { children: ReactNode }) => (
+  <QueryClientProvider client={queryClient}>
+    <RecoilRoot>{children}</RecoilRoot>
+    <ReactQueryDevtools initialIsOpen={false} />
+  </QueryClientProvider>
+);
+
 const App = () => {
   return (
-    <QueryClientProvider client={queryClient}>
+    <AppProvider>
       <BrowserRouter>
-        <RecoilRoot>
-          <div className="wrapper">
-            <Header />
-            <RoutesSetup />
-            <Footer />
-          </div>
-        </RecoilRoot>
+        <div id="wrap">
+          <Header />
+          <RoutesSetup />
+        </div>
+        <Footer />
       </BrowserRouter>
-      <ReactQueryDevtools initialIsOpen={false} />
-    </QueryClientProvider>
+    </AppProvider>
   );
 };
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,9 +24,11 @@ const App = () => {
       <BrowserRouter>
         <div id="wrap">
           <Header />
-          <RoutesSetup />
+          <div id="content">
+            <RoutesSetup />
+          </div>
+          <Footer />
         </div>
-        <Footer />
       </BrowserRouter>
     </AppProvider>
   );

--- a/src/components/auth/LoginForm/index.scss
+++ b/src/components/auth/LoginForm/index.scss
@@ -8,6 +8,7 @@
   background-position: center;
   background-size: cover;
   height: 800px;
+  // min-height: calc(100vh - 56px);
   margin-top: 80px;
 
   .info {

--- a/src/components/auth/LoginForm/index.scss
+++ b/src/components/auth/LoginForm/index.scss
@@ -8,7 +8,6 @@
   background-position: center;
   background-size: cover;
   height: 800px;
-  // min-height: calc(100vh - 56px);
   margin-top: 80px;
 
   .info {

--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -1,6 +1,5 @@
 import Button from '@/components/common/Button';
 import type { FC } from 'react';
-import { Link } from 'react-router-dom';
 
 const Footer: FC = () => {
   return (
@@ -9,32 +8,9 @@ const Footer: FC = () => {
         <div className="wrapper">
           <div className="innerLeft">
             <nav>
-              <Link to="/sample/button">
-                <Button size="small" color="gray" text>
-                  샘플버튼
-                </Button>
-              </Link>
-              <Link to="/sample/grid">
-                <Button size="small" color="gray" text>
-                  샘플그리드
-                </Button>
-              </Link>
-
-              <Link to="/study/create">
-                <Button size="small" color="gray" text>
-                  스터디 생성
-                </Button>
-              </Link>
-              <Link to="/study/edit">
-                <Button size="small" color="gray" text>
-                  스터디 수정
-                </Button>
-              </Link>
-              <Link to="/recruit/edit">
-                <Button size="small" color="gray" text>
-                  구인 글 수정
-                </Button>
-              </Link>
+              <Button size="small" color="gray" text>
+                관리자 문의
+              </Button>
             </nav>
           </div>
           <div className="innerRight">

--- a/src/styles/components/_footer.scss
+++ b/src/styles/components/_footer.scss
@@ -4,9 +4,6 @@ footer {
   background: white;
   border-bottom: 1px solid rgba(17, 81, 115, 0.2);
   box-shadow: 0px 1px 3px rgba(0, 0, 0, 0.25);
-  align-items: flex-start;
-  position: fixed;
-  bottom: 0;
 
   .wrapper {
     display: flex;

--- a/src/styles/components/_recruitCard.scss
+++ b/src/styles/components/_recruitCard.scss
@@ -1,6 +1,7 @@
 .recruit-card-wrapper {
   margin: 100px 0;
 }
+
 .recruit-card {
   background-color: $white;
   border: 1px solid $border;
@@ -63,6 +64,7 @@
     }
   }
 }
+
 .make-study {
   background-color: $white;
   font-size: 30px;

--- a/src/styles/layouts/_grids.scss
+++ b/src/styles/layouts/_grids.scss
@@ -1,56 +1,54 @@
-.container {
-  width: 100%;
-  height: 100%;
-  padding: 0 $sm-margin;
-  margin: 0 auto;
-
-  .row {
-    display: flex;
-    flex-wrap: wrap;
-  }
-
-  [class^='col-'] {
-    padding: 0 calc($gutter / 2);
-  }
-
-  @for $i from 1 through $sm-columns {
-    .col-sm-#{$i} {
-      width: percentage(calc($i / $sm-columns));
-    }
-  }
-
-  @include responsive(md) {
-    max-width: $md-max-container;
-    padding: 0 $md-margin;
-
-    @for $i from 1 through $md-columns {
-      .col-md-#{$i} {
-        width: percentage(calc($i / $md-columns));
-      }
-    }
-  }
-
-  @include responsive(lg) {
-    max-width: $lg-max-container;
-    padding: 0;
-
-    @for $i from 1 through $lg-columns {
-      .col-lg-#{$i} {
-        width: ($lg-unit + $gutter) * $i;
-      }
-    }
-  }
-}
-
-.wrapper {
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  height: 100%;
-}
-
 #wrap {
   height: 100%;
-  padding-bottom: 56px;
-  min-height: calc(100vh - 56px);
+  min-height: 100vh;
+
+  #content {
+    height: 100%;
+    min-height: calc(100vh - 120px);
+    border: 1px solid transparent;
+  }
+
+  .container {
+    width: 100%;
+    height: 100%;
+    padding: 0 $sm-margin;
+    margin: 0 auto;
+
+    .row {
+      display: flex;
+      flex-wrap: wrap;
+    }
+
+    [class^='col-'] {
+      padding: 0 calc($gutter / 2);
+    }
+
+    @for $i from 1 through $sm-columns {
+      .col-sm-#{$i} {
+        width: percentage(calc($i / $sm-columns));
+      }
+    }
+
+    @include responsive(md) {
+      max-width: $md-max-container;
+      padding: 0 $md-margin;
+
+      @for $i from 1 through $md-columns {
+        .col-md-#{$i} {
+          width: percentage(calc($i / $md-columns));
+        }
+      }
+    }
+
+    @include responsive(lg) {
+      max-width: $lg-max-container;
+      padding: 0;
+
+      @for $i from 1 through $lg-columns {
+        .col-lg-#{$i} {
+          width: ($lg-unit + $gutter) * $i;
+        }
+      }
+    }
+  }
 }

--- a/src/styles/layouts/_grids.scss
+++ b/src/styles/layouts/_grids.scss
@@ -46,5 +46,11 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  height: 100vh;
+  height: 100%;
+}
+
+#wrap {
+  height: 100%;
+  padding-bottom: 56px;
+  min-height: calc(100vh - 56px);
 }


### PR DESCRIPTION
# 이 풀리퀘스트는 다음과 같습니다

## 배경

- 컨텐츠 길이에 맞게 푸터 하단 고정

## 작업내용

- 기존 푸터에 있던 페이지를 삭제했습니다. 
- 관리자 문의는 이후 추가할 예정입니다.
- 컨텐츠 길이에 맞게 푸터를 하단에 고정했습니다.

## 리뷰어에게

PR 리뷰어에게 공유할 내용이 있다면 설명해주세요.
이 PR을 리뷰하는 것에 도움이 될 수 있어요.
